### PR TITLE
Fix/correct counter publishing

### DIFF
--- a/src/collectors/nginx/nginx.py
+++ b/src/collectors/nginx/nginx.py
@@ -25,6 +25,9 @@ following content:
   }
 </pre>
 
+Netuitive Change History
+    2016/07/12 DVG - Removed the "requests per connection" metric. See comments inline for more detail.
+
 """
 
 import urllib2
@@ -88,12 +91,28 @@ class NginxCollector(diamond.collector.Collector):
                         int(activeConnectionsRE.match(l).group('conn')))
                 elif totalConnectionsRE.match(l):
                     m = totalConnectionsRE.match(l)
-                    req_per_conn = float(m.group('req')) / \
-                        float(m.group('acc'))
+
+                    ###
+                    #
+                    # 2016/07/12 DVG - Removing the "requests per connection" metric.
+                    # Because this metric was being computed from COUNTER metrics, it
+                    # represented the average requests per connection since the beginning
+                    # of time, which is not particularly useful.
+                    #
+                    # req_per_conn = float(m.group('req')) / \
+                    #    float(m.group('acc'))
+                    #
+                    ###
                     self.publish_counter('conn_accepted', int(m.group('conn')))
                     self.publish_counter('conn_handled', int(m.group('acc')))
                     self.publish_counter('req_handled', int(m.group('req')))
-                    self.publish_gauge('req_per_conn', float(req_per_conn))
+                    ###
+                    # 
+                    # 2016/07/12 DVG - see comment above
+                    #
+                    # self.publish_gauge('req_per_conn', float(req_per_conn))
+                    #
+                    ###
                 elif connectionStatusRE.match(l):
                     m = connectionStatusRE.match(l)
                     self.publish_gauge('act_reads', int(m.group('reading')))

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -2,6 +2,11 @@
 
 """
 The Collector class is a base class for all metric collectors.
+
+Netuitive Change History
+    2016/07/11 DVG - Changed the publish_counter() function such that it actually does publish the 
+                     value as a COUNTER rather than a RATE. See comments inline for more detail.
+
 """
 
 import os
@@ -413,12 +418,24 @@ class Collector(object):
     def publish_counter(self, name, value, precision=0, max_value=0,
                         time_delta=True, interval=None, allow_negative=False,
                         instance=None):
-        raw_value = value
-        value = self.derivative(name, value, max_value=max_value,
-                                time_delta=time_delta, interval=interval,
-                                allow_negative=allow_negative,
-                                instance=instance)
-        return self.publish(name, value, raw_value=raw_value,
+        
+        ###
+        #
+        # 2016/07/11 DVG - The original version of this code was calling
+        # self.derivative(), which first computes the differential (the
+        # difference between the current value and the previous value),
+        # and then divides by the interval. The end result was that the 
+        # value published was a RATE and not actually a COUNTER, despite 
+        # the type being set to COUNTER.
+        #
+        ###
+
+        # raw_value = value
+        # value = self.derivative(name, value, max_value=max_value,
+        #                         time_delta=time_delta, interval=interval,
+        #                         allow_negative=allow_negative,
+        #                         instance=instance)
+        return self.publish(name, value, 
                             precision=precision, metric_type='COUNTER',
                             instance=instance)
 


### PR DESCRIPTION
Three changes were made as part of this branch:

**collector.py** - Changed the _publish_counter()_ method.  The original version was calling _self.derivative()_, which first computes the differential and then divides by the interval. The end result was that the value published was a RATE and not actually a COUNTER, despite the type being set to COUNTER.

**nginx.py** - Removed the "requests per connection" metric.  Because this metric was being computed from COUNTER metrics, it represented the average requests per connection since the beginning of time, which is not particularly useful.

**mysqlstat.py** - Send COUNTERS as COUNTERS, rather then converting them to rates and sending as GAUGUES.
