### PR TITLE
Only remove the leading forward slash from Docker container names

### DIFF
--- a/src/collectors/netuitivedocker/netuitivedocker.py
+++ b/src/collectors/netuitivedocker/netuitivedocker.py
@@ -57,8 +57,6 @@ class NetuitiveDockerCollector(diamond.collector.Collector):
         def print_metric(cc, name):
             data = cc.stats(name)
             metrics = json.loads(data.next())
-            if name.find("/") != -1:
-                name = name.rsplit('/', 1)[1]
             # memory metrics
             self.memory = self.flatten_dict(metrics['memory_stats'])
             for key, value in self.memory.items():
@@ -128,7 +126,8 @@ class NetuitiveDockerCollector(diamond.collector.Collector):
         threads = []
 
         for dname in dockernames:
-            t = threading.Thread(target=print_metric, args=(cc, dname[0][1:]))
+            name = next(n for n in dname if n.count('/') == 1)
+            t = threading.Thread(target=print_metric, args=(cc, name[1:]))
             threads.append(t)
             t.start()
 


### PR DESCRIPTION
Linked container names can be of the form /parent-name/container-name. The previous implementation would only split once starting from the end to pull the child container name only (container-name). This change will only remove the leading / to get parent-name/container-name.

Closes #62