### PR TITLE
Add UDP protocol option to portcheck collector

### DIFF
--- a/src/collectors/portcheck/portcheck.py
+++ b/src/collectors/portcheck/portcheck.py
@@ -49,7 +49,7 @@ def get_port_stats(port, proto):
         if proto == 'tcp':
                 status = c.status.lower()
         cnts[status] += 1
-        return cnts
+    return cnts
 
 
 class PortCheckCollector(diamond.collector.Collector):

--- a/src/collectors/portcheck/portcheck.py
+++ b/src/collectors/portcheck/portcheck.py
@@ -14,7 +14,7 @@ ttl = 150
 [port]
 [[echo]]
 number = 8080
-proto = tcp
+protocol = tcp
 ```
 
 """
@@ -64,7 +64,7 @@ class PortCheckCollector(diamond.collector.Collector):
             port_cfg = {}
             for key in ('number',):
                 port_cfg[key] = cfg.get(key, [])
-            for key in ('proto',):
+            for key in ('protocol',):
                 port_cfg[key] = cfg.get(key, [])
             self.ports[port_name] = port_cfg
 
@@ -105,10 +105,10 @@ class PortCheckCollector(diamond.collector.Collector):
 
         for port_name, port_cfg in self.ports.iteritems():
             port = int(port_cfg['number'])
-            if port_cfg['proto'] == []:
+            if port_cfg['protocol'] == []:
                 proto = 'tcp'
             else:
-                proto = str(port_cfg['proto'])
+                proto = str(port_cfg['protocol'])
             stats = get_port_stats(port, proto)
             for stat_name, stat_value in stats.iteritems():
                 if stat_name == 'listen' and stat_value >= 1:

--- a/src/collectors/portcheck/portcheck.py
+++ b/src/collectors/portcheck/portcheck.py
@@ -33,20 +33,20 @@ except ImportError:
     netuitive = None
 
 
-def get_port_stats(port, proto):
+def get_port_stats(port, protocol):
     """
     Iterate over connections and count states for specified port
     :param port: port for which stats are collected
     :return: Counter with port states
     """
     cnts = defaultdict(int)
-    for c in psutil.net_connections(proto):
+    for c in psutil.net_connections(protocol):
         c_port = c.laddr[1]
         if c_port != port:
                 continue
-        if proto == 'udp':
+        if protocol == 'udp':
                 status = 'listen'
-        if proto == 'tcp':
+        if protocol == 'tcp':
                 status = c.status.lower()
         cnts[status] += 1
     return cnts
@@ -90,7 +90,7 @@ class PortCheckCollector(diamond.collector.Collector):
         config.update({
             'path': 'port',
             'port': {},
-            'proto': 'tcp'
+            'protocol': 'tcp'
         })
         return config
 
@@ -106,10 +106,10 @@ class PortCheckCollector(diamond.collector.Collector):
         for port_name, port_cfg in self.ports.iteritems():
             port = int(port_cfg['number'])
             if port_cfg['protocol'] == []:
-                proto = 'tcp'
+                protocol = 'tcp'
             else:
-                proto = str(port_cfg['protocol'])
-            stats = get_port_stats(port, proto)
+                protocol = str(port_cfg['protocol'])
+            stats = get_port_stats(port, protocol)
             for stat_name, stat_value in stats.iteritems():
                 if stat_name == 'listen' and stat_value >= 1:
                     check_name = '%s.%d' % (port_name, port)


### PR DESCRIPTION
And make tcp default proto for backwards compatability.  This is used by psutil.net_connections().  Since UDP connections are stateless, we ignore null status and simply check if the connection exists, unlike the tcp check. fixes #85 