### PR TITLE
Submit some metrics as COUNTER instead of GAUGE

### DIFF
--- a/src/collectors/haproxy/haproxy.py
+++ b/src/collectors/haproxy/haproxy.py
@@ -19,6 +19,13 @@ import diamond.collector
 
 
 class HAProxyCollector(diamond.collector.Collector):
+    COUNTER_METRICS = [
+        'bin', 'bout', 'chkdown', 'chkfail', 'cli_abrt', 'comp_byp', 'comp_in',
+        'comp_out', 'comp_rsp', 'conn_tot', 'downtime', 'dreq', 'dresp',
+        'econ', 'ereq', 'eresp', 'hrsp_1xx', 'hrsp_2xx', 'hrsp_3xx',
+        'hrsp_4xx', 'hrsp_5xx', 'hrsp_other', 'intercepted', 'lbtot',
+        'srv_abrt', 'stot', 'wredis', 'wretr'
+    ]
 
     def get_default_config_help(self):
         config_help = super(HAProxyCollector, self).get_default_config_help()
@@ -167,7 +174,13 @@ class HAProxyCollector(diamond.collector.Collector):
                     continue
 
                 stat_name = '%s.%s' % (metric_name, headings[index])
-                self.publish(stat_name, metric_value, metric_type='GAUGE')
+                self.publish(stat_name, metric_value, metric_type=self._metric_type(headings[index]))
+
+    def _metric_type(self, metric_name):
+        if metric_name in self.COUNTER_METRICS:
+            return 'COUNTER'
+        else:
+            return 'GAUGE'
 
     def collect(self):
         if 'servers' in self.config:

--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -67,20 +67,12 @@ class PuppetDBCollector(diamond.collector.Collector):
         'queue.Size':
                 "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
                 "name=global.size",
-        'processing-time':
-            "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
-            "name=global.processing-time",
         'processed':
             "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
             "name=global.processed",
         'retried':
             "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
             "name=global.retried",
-        'discarded':
-            "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
-            "name=global.discarded",
-        'fatal': "metrics/v1/mbeans/puppetlabs.puppetdb.mq:" +
-                 "name=global.fatal",
         'commands.service-time':
             "metrics/v1/mbeans/puppetlabs.puppetdb." +
             "http:name=/pdb/cmd/v1.service-time",
@@ -146,12 +138,6 @@ class PuppetDBCollector(diamond.collector.Collector):
         self.publish_gauge('catalog_duplicate_pct',
                            rawmetrics['duplicate-pct']['Value'])
         self.publish_gauge(
-            'sec_command',
-            time_convertor.convert(
-                rawmetrics['processing-time']['50thPercentile'],
-                rawmetrics['processing-time']['DurationUnit'],
-                'seconds'))
-        self.publish_gauge(
             'resources_service_time',
             time_convertor.convert(
                 rawmetrics['resources.service-time']['50thPercentile'],
@@ -164,9 +150,7 @@ class PuppetDBCollector(diamond.collector.Collector):
                 rawmetrics['commands.service-time']['DurationUnit'],
                 'seconds'))
 
-        self.publish_gauge('discarded', rawmetrics['discarded']['Count'])
         self.publish_gauge('processed', rawmetrics['processed']['Count'])
-        self.publish_gauge('rejected', rawmetrics['fatal']['Count'])
         self.publish_gauge(
             'DB_Compaction',
             time_convertor.convert(


### PR DESCRIPTION
Metricly treats counters in a special way so it can show a change over time. For some metrics that's much more preferable than an a total value over all time.