### PR TITLE
Pass over transport metrics when they do not exist

### DIFF
--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -274,15 +274,12 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
         metrics['indices.datastore.size'] = indices['store']['size_in_bytes']
 
-        try:
+        if 'transport' in metrics:
             transport = data['transport']
             metrics['transport.rx.count'] = transport['rx_count']
             metrics['transport.rx.size'] = transport['rx_size_in_bytes']
             metrics['transport.tx.count'] = transport['tx_count']
             metrics['transport.tx.size'] = transport['tx_size_in_bytes']
-        except KeyError:
-            self.log.debug("Could not find transport stats")
-            pass
 
         # elasticsearch < 0.90RC2
         if 'cache' in indices:

--- a/src/collectors/elasticsearch/elasticsearch.py
+++ b/src/collectors/elasticsearch/elasticsearch.py
@@ -274,11 +274,15 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
         metrics['indices.datastore.size'] = indices['store']['size_in_bytes']
 
-        transport = data['transport']
-        metrics['transport.rx.count'] = transport['rx_count']
-        metrics['transport.rx.size'] = transport['rx_size_in_bytes']
-        metrics['transport.tx.count'] = transport['tx_count']
-        metrics['transport.tx.size'] = transport['tx_size_in_bytes']
+        try:
+            transport = data['transport']
+            metrics['transport.rx.count'] = transport['rx_count']
+            metrics['transport.rx.size'] = transport['rx_size_in_bytes']
+            metrics['transport.tx.count'] = transport['tx_count']
+            metrics['transport.tx.size'] = transport['tx_size_in_bytes']
+        except KeyError:
+            self.log.debug("Could not find transport stats")
+            pass
 
         # elasticsearch < 0.90RC2
         if 'cache' in indices:


### PR DESCRIPTION
Transport metrics don't exist for single node clusters as the metrics represent stats on internal communication between many nodes.