### PR TITLE
Bugfix/puppetdb collector nodes metrics

### DIFF
--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -270,8 +270,7 @@ class PuppetDBCollector(diamond.collector.Collector):
                            rawmetrics['memory']['HeapMemoryUsage']['used'])
         self.publish_gauge('memory.HeapMemoryUsage.committed',
                            rawmetrics['memory']['HeapMemoryUsage']['committed'])
-        self.publish_gauge('nodes.status.unchanged', nodestats['unchanged'])
-        self.publish_gauge('nodes.status.changed', nodestats['changed'])
-        self.publish_gauge('nodes.status.failed', nodestats['failed'])
-        self.publish_gauge('nodes.status.unreported', nodestats['unreported'])
+        self.publish_gauge('nodes.status.failures', nodestats['failures'])
+        self.publish_gauge('nodes.status.skips', nodestats['skips'])
+        self.publish_gauge('nodes.status.successes', nodestats['successes'])
         self.publish_gauge('nodes.status.noops', nodestats['noops'])

--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -282,4 +282,4 @@ class PuppetDBCollector(diamond.collector.Collector):
         self.publish_gauge('nodes.status.changed', nodestats['changed'])
         self.publish_gauge('nodes.status.failed', nodestats['failed'])
         self.publish_gauge('nodes.status.unreported', nodestats['unreported'])
-        self.publish_gauge('nodes.status.pending', nodestats['noop'])
+        self.publish_gauge('nodes.status.noops', nodestats['noops'])

--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -144,7 +144,7 @@ class PuppetDBCollector(diamond.collector.Collector):
 
         try:
             url = "http://%s:%s/%s" % (
-                self.config['host'], int(self.config['port']), "pdb/query/v4/event-counts?query=%5B%22%3D%22%2C%22latest_report%3F%22%2Ctrue%5D&summarize_by=certname")
+                self.config['host'], int(self.config['port']), "pdb/query/v4/events?query=%5B%22%3D%22%2C%22latest_report%3F%22%2Ctrue%5D")
             response = urllib2.urlopen(url)
         except Exception, e:
             self.log.error('Couldn\'t connect to puppetdb: %s -> %s', url, e)
@@ -152,31 +152,23 @@ class PuppetDBCollector(diamond.collector.Collector):
         event_counts = json.load(response)
 
         stats = {
-            'changed': 0,
-            'unchanged': 0,
-            'failed': 0,
-            'unreported': 0,
-            'noop': 0
+            'failures': 0,
+            'skips': 0,
+            'successes': 0,
+            'noops': 0
         }
 
         for node in nodes:
-            status = [event for event in event_counts
-                      if event['subject']['title'] == node['certname']]
-            update_delta = now - \
-                datetime.strptime(node['report_timestamp'],
-                                  '%Y-%m-%dT%H:%M:%S.%fZ')
-            if update_delta.days > 0 or update_delta.seconds > 7200:
-                status = 'unreported'
-            if status == 'unreported':
-                stats['unreported'] += 1
-            elif status == 'changed':
-                stats['changed'] += 1
-            elif status == 'failed':
-                stats['failed'] += 1
-            elif status == 'noop':
-                stats['noop'] += 1
-            else:
-                stats['unchanged'] += 1
+            status = [event['status'] for event in event_counts
+                      if event['certname'] == node['certname']]
+            if 'failure' in status:
+                stats['failures'] += status.count('failure')
+            if 'skipped' in status:
+                stats['skips'] += status.count('skipped')
+            if 'success' in status:
+                stats['successes'] += status.count('success')
+            if 'noop' in status:
+                stats['noops'] += status.count('noop')
 
         return stats
 


### PR DESCRIPTION
It appears this was written to use the events API, but the event-counts API is the one specified. This means the node status metrics were not functional. The proposed changes include specifying the events API, and modifications for successful node status metric generation and transmission.

The changes have been tested internally and are now undergoing external user testing. Reviewers will be requested when all testing is complete and we see the desired results.