### PR TITLE
Ask for certname and status only

### DIFF
--- a/src/collectors/puppetdb/puppetdb.py
+++ b/src/collectors/puppetdb/puppetdb.py
@@ -144,7 +144,7 @@ class PuppetDBCollector(diamond.collector.Collector):
 
         try:
             url = "http://%s:%s/%s" % (
-                self.config['host'], int(self.config['port']), "pdb/query/v4/events?query=%5B%22%3D%22%2C%22latest_report%3F%22%2Ctrue%5D")
+                self.config['host'], int(self.config['port']), "pdb/query/v4/events?query=%5B%22extract%22%2C%5B%22status%22%2C%22certname%22%5D%2C%5B%22%3D%22%2C%22latest_report%3F%22%2Ctrue%5D%5D")
             response = urllib2.urlopen(url)
         except Exception, e:
             self.log.error('Couldn\'t connect to puppetdb: %s -> %s', url, e)


### PR DESCRIPTION
The events API latest reports can have a lot of data, especially if there are many puppet agents and configurations. The certname and status parameters are all the collector needs to produce node  status metrics. This change is a modification to the query such that only certname and status are included in the response, drastically reducing the amount of data asked for by the collector.